### PR TITLE
Fix compatibility

### DIFF
--- a/.changeset/grumpy-fireants-melt.md
+++ b/.changeset/grumpy-fireants-melt.md
@@ -1,0 +1,5 @@
+---
+'nuxt-svgo': patch
+---
+
+Update compatibility to '^3.0.0-rc.0'

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,8 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'nuxt-svgo',
     configKey: 'svgo',
     compatibility: {
-      nuxt: '^3.0.0'
+      // Add -rc.0 due to issue described in https://github.com/nuxt/framework/issues/6699
+      nuxt: '^3.0.0-rc.0'
     }
   },
   defaults: {


### PR DESCRIPTION
As described in https://github.com/nuxt/framework/issues/6699, nuxt currently removes the prerelease tag before comparing versions.

This is a workaround until nuxt@3.0.0-rc.9 is released (PR with fix: https://github.com/nuxt/framework/pull/7116)

