### PR TITLE
fix: consolidate script tags to fix ts build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-svgo",
-  "version": "1.1.1-development",
+  "version": "1.2.1",
   "packageManager": "pnpm@8.2.0",
   "description": "Nuxt module to load optimized SVG files as Vue components",
   "keywords": [

--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -1,5 +1,6 @@
 <template>
-  <component :is="IconComponent"
+  <component
+    :is="IconComponent"
     :class="{
       'nuxt-icon': fontControlled,
       'nuxt-icon--fill': !filled
@@ -33,17 +34,17 @@ export default {
   props: {
     name: {
       type: String,
-      required: true,
+      required: true
     },
     filled: {
-      type: Boolean, 
+      type: Boolean,
       required: false,
-      default: false,
+      default: false
     },
     fontControlled: {
-      type: Boolean, 
+      type: Boolean,
       required: false,
-      default: true,
+      default: true
     }
   },
   setup(props) {
@@ -67,7 +68,7 @@ export default {
     )
 
     return {
-      IconComponent,
+      IconComponent
     }
   }
 }

--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <IconComponent
+  <component :is="IconComponent"
     :class="{
       'nuxt-icon': fontControlled,
       'nuxt-icon--fill': !filled
@@ -8,7 +8,9 @@
 </template>
 
 <script lang="ts">
-import { h } from '#imports'
+// file imported from https://github.com/gitFoxCode/nuxt-icons/blob/89e53649e5868c31fc97869918ede96504ae1a04/src/runtime/components/nuxt-icon.vue
+// with some modifications
+import { shallowRef, watch, h } from '#imports'
 
 const iconsImport = import.meta.glob('assets/icons/**/**.svg', {
   import: 'default',
@@ -26,40 +28,49 @@ function IconNotFound(name: string) {
     }
   }
 }
-</script>
 
-<script setup lang="ts">
-// file imported from https://github.com/gitFoxCode/nuxt-icons/blob/89e53649e5868c31fc97869918ede96504ae1a04/src/runtime/components/nuxt-icon.vue
-// with some modifications
-import { markRaw, watch } from '#imports'
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    filled: {
+      type: Boolean, 
+      required: false,
+      default: false,
+    },
+    fontControlled: {
+      type: Boolean, 
+      required: false,
+      default: true,
+    }
+  },
+  setup(props) {
+    const IconComponent = shallowRef(
+      iconsImport[`/assets/icons/${props.name}.svg`] || IconNotFound(props.name)
+    )
 
-const props = withDefaults(
-  defineProps<{
-    name: string
-    fontControlled?: boolean
-    filled?: boolean
-  }>(),
-  { filled: false, fontControlled: true }
-)
+    watch(
+      () => props.name,
+      () => {
+        const component = iconsImport[`/assets/icons/${props.name}.svg`]
+        if (!component) {
+          console.error(
+            `[nuxt-svgo] Icon '${props.name}' doesn't exist in 'assets/icons'`
+          )
+          IconComponent.value = IconNotFound(props.name)
+        } else {
+          IconComponent.value = component
+        }
+      }
+    )
 
-const IconComponent = markRaw(
-  iconsImport[`/assets/icons/${props.name}.svg`] || IconNotFound(props.name)
-)
-
-watch(
-  () => props.name,
-  () => {
-    const component = iconsImport[`/assets/icons/${props.name}.svg`]
-    if (!component) {
-      console.error(
-        `[nuxt-svgo] Icon '${props.name}' doesn't exist in 'assets/icons'`
-      )
-      IconComponent.value = IconNotFound(props.name)
-    } else {
-      IconComponent.value = component
+    return {
+      IconComponent,
     }
   }
-)
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
@cpsoinos here is the fix
the reason for the error was the issue at upstream: https://github.com/nuxt/module-builder/issues/96 and https://github.com/unjs/mkdist/issues/22

the build was removing the tag

so for now the way to fix it is to ditch the setup tag
we can maybe bring the old style back once the upstream is fixed :)