### PR TITLE
fix: wrap icon in span

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-svgo",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packageManager": "pnpm@8.2.0",
   "description": "Nuxt module to load optimized SVG files as Vue components",
   "keywords": [

--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -5,9 +5,7 @@
       'nuxt-icon--fill': !filled
     }"
   >
-    <component
-      :is="IconComponent"
-    />
+    <component :is="IconComponent" />
   </span>
 </template>
 

--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -1,11 +1,14 @@
 <template>
-  <component
-    :is="IconComponent"
+  <span
     :class="{
       'nuxt-icon': fontControlled,
       'nuxt-icon--fill': !filled
     }"
-  />
+  >
+    <component
+      :is="IconComponent"
+    />
+  </span>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
the icon sizing using font doesnt work without wrapping it in span
sorry, my bad to not test it out

it was in the original implementaion (on nuxt-icons)