### PR TITLE
fix: update default config to be empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-svgo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packageManager": "pnpm@8.2.0",
   "description": "Nuxt module to load optimized SVG files as Vue components",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-svgo",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "packageManager": "pnpm@8.2.0",
   "description": "Nuxt module to load optimized SVG files as Vue components",
   "keywords": [

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,19 +27,7 @@ const nuxtSvgo: NuxtModule<ModuleOptions> = defineNuxtModule({
   defaults: {
     svgo: true,
     defaultImport: 'component',
-    svgoConfig: {
-      plugins: [
-        {
-          name: 'preset-default',
-          params: {
-            overrides: {
-              removeViewBox: false
-            }
-          }
-        },
-        'removeDimensions'
-      ]
-    },
+    svgoConfig: {},
     autoImportPath: './assets/icons/',
     simpleAutoImport: false
   },

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -11,7 +11,7 @@ describe('default options', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
     expect(html).toContain(
-      '<svg viewBox="0 0 24 24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732l-7.5-4.33z"></path></svg>'
+      '<svg width="24" height="24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732l-7.5-4.33z"></path></svg>'
     )
   })
 })

--- a/test/override.test.ts
+++ b/test/override.test.ts
@@ -12,10 +12,8 @@ describe('default options', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
 
-    console.log(html)
-
     expect(html).toContain(
-      '<svg viewBox="0 0 24 24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732l-7.5-4.33z"></path></svg>'
+      '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732l-7.5-4.33z"></path></svg>'
     )
   })
 })


### PR DESCRIPTION
When I proposed changing default config I wasn't aware of the horrible merging strategy of the config
one of my friends was trying to use this and I was shocked to see array's were merging instead of replacing, which made it impossible to remove the `removeDimensions` plugin.

given the horrible unexpected outcome, I suggest changing it back to nothing (sadly)
