### PR TITLE
feat: add global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ export default defineNuxtConfig({
 })
 ```
 
+By default module registers all icons inside `autoImportPath` globally. This may be unwanted behavior as it generated chunks for each icon to be used globally, which will result in huge amount of files if you have many icons. If you want to disable global registeration simply use `global: false` in module options:
+
+```typescript
+// nuxt.config.ts
+import { defineNuxtConfig } from 'nuxt'
+
+export default defineNuxtConfig({
+  modules: ['nuxt-svgo'],
+  svgo: {
+    global: false
+  }
+})
+```
+
 ### Subfolders
 
 The icons's component name will follow Nuxt's component prefix convention. Therefore, if prefix is turned on for your components, the component name for `assets/icons/admin/badge.svg`, for example, will be `svgo-admin-badge`:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export default defineNuxtConfig({
 })
 ```
 
-By default module registers all icons inside `autoImportPath` globally. This may be unwanted behavior as it generated chunks for each icon to be used globally, which will result in huge amount of files if you have many icons. If you want to disable global registeration simply use `global: false` in module options:
+By default module registers all icons inside `autoImportPath` globally. This may be unwanted behavior as it generates chunks for each icon to be used globally, which will result in huge amount of files if you have many icons. If you want to disable global registration simply use `global: false` in module options:
 
 ```typescript
 // nuxt.config.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-svgo",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "packageManager": "pnpm@8.4.0",
   "description": "Nuxt module to load optimized SVG files as Vue components",
   "keywords": [

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,6 +27,7 @@ export const defaultSvgoConfig: Config = {
 
 export type ModuleOptions = SvgLoaderOptions & {
   autoImportPath?: string
+  global?: boolean
 }
 
 const nuxtSvgo: NuxtModule<ModuleOptions> = defineNuxtModule({
@@ -42,7 +43,8 @@ const nuxtSvgo: NuxtModule<ModuleOptions> = defineNuxtModule({
     svgo: true,
     defaultImport: 'componentext',
     autoImportPath: './assets/icons/',
-    svgoConfig: undefined
+    svgoConfig: undefined,
+    global: true
   },
   async setup(options) {
     const { resolvePath, resolve } = createResolver(import.meta.url)
@@ -62,7 +64,7 @@ const nuxtSvgo: NuxtModule<ModuleOptions> = defineNuxtModule({
     if (options.autoImportPath) {
       addComponentsDir({
         path: await resolvePath(options.autoImportPath),
-        global: true,
+        global: options.global,
         extensions: ['svg'],
         prefix: 'svgo',
         watch: true


### PR DESCRIPTION
this PR adds `global` option to module which controls the global registration of the icon components