### PR TITLE
Missing type in SVGLoaderOptions

### DIFF
--- a/src/loaders/vite.ts
+++ b/src/loaders/vite.ts
@@ -7,7 +7,7 @@ import { optimize as optimizeSvg, Config } from 'svgo'
 import urlEncodeSvg from 'mini-svg-data-uri'
 
 export interface SvgLoaderOptions {
-  autoImportPath?: string
+  autoImportPath?: string | boolean
   /** The name of component in CapitalCase that will be used in `componentext` import type. defaults to `NuxtIcon` */
   customComponent: string
   defaultImport?:


### PR DESCRIPTION
Added missing union type in SVGLoaderOptions.

This fixes the error when disabling auto import by setting autoImportPath to false

![image](https://github.com/cpsoinos/nuxt-svgo/assets/134087665/4578729c-c30f-4c8c-8f01-187106fadd09)
