### PR TITLE
fix: Add missing type to vite.ts

### DIFF
--- a/src/loaders/vite.ts
+++ b/src/loaders/vite.ts
@@ -7,7 +7,7 @@ import { optimize as optimizeSvg, Config } from 'svgo'
 import urlEncodeSvg from 'mini-svg-data-uri'
 
 export interface SvgLoaderOptions {
-  autoImportPath?: string
+  autoImportPath?: string | boolean
   /** The name of component in CapitalCase that will be used in `componentext` import type. defaults to `NuxtIcon` */
   customComponent: string
   defaultImport?:

--- a/src/loaders/vite.ts
+++ b/src/loaders/vite.ts
@@ -7,7 +7,7 @@ import { optimize as optimizeSvg, Config } from 'svgo'
 import urlEncodeSvg from 'mini-svg-data-uri'
 
 export interface SvgLoaderOptions {
-  autoImportPath?: string | boolean
+  autoImportPath?: string | false
   /** The name of component in CapitalCase that will be used in `componentext` import type. defaults to `NuxtIcon` */
   customComponent: string
   defaultImport?:


### PR DESCRIPTION
Added missing type to fix error while disabling auto import
![image](https://github.com/cpsoinos/nuxt-svgo/assets/134087665/6fcfda04-06dd-42a9-95d8-36f6ee557a4b)
