### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,6 @@ Try it on [StackBlitz](https://stackblitz.com/edit/nuxt-svgo-playground?file=nux
 
 ## Install
 
-### Using `npm`
-
-```sh
-npx nuxi@latest module add nuxt-svgo
-```
-
-### Using `yarn`
-
-```sh
-npx nuxi@latest module add nuxt-svgo
-```
-
-### Using `pnpm`
-
 ```sh
 npx nuxi@latest module add nuxt-svgo
 ```

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ Try it on [StackBlitz](https://stackblitz.com/edit/nuxt-svgo-playground?file=nux
 ### Using `npm`
 
 ```sh
-npm install nuxt-svgo --save-dev
+npx nuxi@latest module add nuxt-svgo
 ```
 
 ### Using `yarn`
 
 ```sh
-yarn add nuxt-svgo -D
+npx nuxi@latest module add nuxt-svgo
 ```
 
 ### Using `pnpm`
 
 ```sh
-pnpm add nuxt-svgo -D
+npx nuxi@latest module add nuxt-svgo
 ```
 
 ## Usage


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
