### PR TITLE
fix: add missing permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
+  contents: write # Required for semantic-release to push version tags
+  issues: write # Required for semantic-release to create failure issues
+  pull-requests: write # Required for semantic-release to comment on PRs
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Fixes the release workflow failing with `EGITNOPERMISSION` and `Resource not accessible by integration` (403) errors.

## Root Cause

When any `permissions` key is specified in a GitHub Actions workflow, all unspecified permissions default to `none`. The workflow only declared `id-token: write`, so `github-actions[bot]` had no `contents` or `issues` permissions — both required by `semantic-release`.

**Errors observed:**
- `EGITNOPERMISSION` — `semantic-release` could not push the version tag to `main`
- `Resource not accessible by integration` — `semantic-release` could not create a failure issue report

## Changes

### `.github/workflows/release.yml`
- Added `contents: write` — required for `semantic-release` to push version tags
- Added `issues: write` — required for `semantic-release` to create failure issue reports
- Added `pull-requests: write` — required for `semantic-release` to comment on PRs