### PR TITLE
fix: publish to npm via OIDC provenance instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm semantic-release
+
+      - name: Publish to npm
+        run: pnpm publish --provenance --no-git-checks

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,16 @@
 {
   "branches": [
     "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

Removes the dependency on the `NPM_TOKEN` secret by switching to npm's native OIDC trusted publishing. No token to rotate, no expiration date.

## Root Cause

The `NPM_TOKEN` secret had expired/was invalid (`EINVALIDNPMTOKEN` / `401 Unauthorized`). npm's granular tokens now have a maximum 90-day expiration, making long-term CI secrets impractical.

## Solution

Use npm's **trusted publisher** (OIDC) flow instead:

1. `@semantic-release/npm` is configured with `npmPublish: false` — this skips the `npm whoami` token verification check while still allowing semantic-release to bump `package.json` and create the GitHub release
2. A separate `pnpm publish --provenance` step exchanges the GitHub Actions OIDC token (via the existing `id-token: write` permission) for a short-lived npm publish credential automatically

## Changes

### `.releaserc`
- Explicitly lists default plugins with `"npmPublish": false` on `@semantic-release/npm`

### `.github/workflows/release.yml`
- Removed `NPM_TOKEN` env var from the Release step
- Added `Publish to npm` step using `pnpm publish --provenance --no-git-checks`

## Prerequisites

Before this will work, a **trusted publisher** must be configured on npmjs.com:

1. Go to the `nuxt-svgo` package on npmjs.com → **Settings** → **Publishing Access**
2. Add a trusted publisher:
   - Owner: `cpsoinos`
   - Repository: `nuxt-svgo`
   - Workflow: `release.yml`
   - Environment: *(leave blank)*