### PR TITLE
fix: use npm publish instead of pnpm publish for OIDC provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
         run: pnpm semantic-release
 
       - name: Publish to npm
-        run: pnpm publish --provenance --no-git-checks
+        run: npm publish --provenance --no-git-checks


### PR DESCRIPTION
## Summary

Fixes `ENEEDAUTH` during `pnpm publish --provenance` by switching to `npm publish --provenance`.

## Root Cause

`pnpm publish` does not wire up the GitHub OIDC environment variables (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) that npm's trusted publishing flow requires. As a result, the OIDC token exchange never happens and npm falls back to requiring an auth token — which we intentionally removed.

`npm publish --provenance` handles the OIDC exchange natively.

## Changes

### `.github/workflows/release.yml`
- `pnpm publish --provenance --no-git-checks` → `npm publish --provenance --no-git-checks`