### PR TITLE
fix: add registry-url to setup-node to enable OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0


### PR DESCRIPTION
## Summary

Fixes `ENEEDAUTH` during `npm publish --provenance` by adding `registry-url` to the `actions/setup-node` step.

## Root Cause

`actions/setup-node` only writes the npm registry auth configuration (the `.npmrc` that wires up `NODE_AUTH_TOKEN` and enables OIDC token exchange) when `registry-url` is explicitly provided. Without it, npm has no auth infrastructure configured and immediately falls back to `ENEEDAUTH` — never attempting the OIDC flow.

## Changes

### `.github/workflows/release.yml`
- Added `registry-url: 'https://registry.npmjs.org'` to the `Setup node.js` step