### PR TITLE
fix: clear NODE_AUTH_TOKEN for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
## Summary

Fixes `E404 Not Found` during `npm publish --provenance` by clearing `NODE_AUTH_TOKEN` in the publish step.

## Root Cause

`actions/setup-node` with `registry-url` automatically sets `NODE_AUTH_TOKEN` to `GITHUB_TOKEN` (its default `token` input). The generated `.npmrc` uses this as the npm auth token — but `GITHUB_TOKEN` is not valid for the npm registry, so it returns `404` (a security-obscured auth failure) instead of authenticating via OIDC.

When `NODE_AUTH_TOKEN` is explicitly set to an empty string, npm skips token auth entirely and falls through to OIDC trusted publishing, which exchanges the GitHub Actions OIDC token for a short-lived npm publish credential.

## Changes

### `.github/workflows/release.yml`
- Added `NODE_AUTH_TOKEN: ''` env to the `Publish to npm` step