### PR TITLE
fix: use _authType=web in npmrc for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0
@@ -54,6 +53,6 @@ jobs:
         run: pnpm semantic-release
 
       - name: Publish to npm
-        run: npm publish --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ''
+        run: |
+          echo '//registry.npmjs.org/:_authType=web' > ~/.npmrc
+          npm publish --provenance --no-git-checks


### PR DESCRIPTION
## Summary

Fixes `ENEEDAUTH` by writing a minimal `.npmrc` with `_authType=web` instead of relying on `actions/setup-node`'s auth injection.

## Root Cause

When `NODE_AUTH_TOKEN` is empty, npm doesn't fall through to OIDC — it still looks for `_authToken` in `.npmrc`, finds it set to an empty string, and rejects as unauthenticated. The OIDC exchange requires `_authType=web` to be explicitly declared, telling npm to use the web/OIDC auth flow instead.

The previous approach of `registry-url` + `NODE_AUTH_TOKEN: ''` was close but npm requires the positive opt-in of `_authType=web`, not just the absence of a token.

## Changes

### `.github/workflows/release.yml`
- Removed `registry-url` from `setup-node` (stops it writing a broken `_authToken` entry)
- Write a minimal `.npmrc` with `//registry.npmjs.org/:_authType=web` immediately before publish