### PR TITLE
fix: correct npm trusted publishing setup per official docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
@@ -54,6 +54,4 @@ jobs:
         run: pnpm semantic-release
 
       - name: Publish to npm
-        run: npm publish --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ''
+        run: npm publish --no-git-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm


### PR DESCRIPTION
## Summary

Corrects the npm trusted publishing workflow based on the [official npm documentation](https://docs.npmjs.com/trusted-publishers).

## Root Cause of Previous Failures

Two issues were blocking OIDC trusted publishing:

1. **Node 20 is too old** — trusted publishing requires npm CLI ≥11.5.1 and Node ≥22.14.0
2. **`NODE_AUTH_TOKEN` must be absent, not empty** — when set to `''`, npm sees an empty token and returns `ENEEDAUTH`. When the env var is simply not set, npm's `.npmrc` reference `${NODE_AUTH_TOKEN}` is unresolved and npm falls through to OIDC automatically

## Changes

### `.github/workflows/release.yml`
- `node-version: 20` → `node-version: 24`
- `registry-url: 'https://registry.npmjs.org'` restored (needed for `.npmrc` setup)
- `NODE_AUTH_TOKEN: ''` removed from publish step — env var must be absent, not empty
- `--provenance` flag removed — provenance is generated automatically when publishing via trusted publishing from GitHub Actions (no flag needed)