### PR TITLE
feat: upgrade svgo to v4.x and fix removeViewBox warning (fixes #474)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ export default defineNuxtConfig({
 
               // or disable plugins
               removeDoctype: false,
-              removeViewBox: false,
             },
           },
         },
@@ -213,6 +212,12 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+> **Note:** In SVGO v4, `removeViewBox` is no longer part of `preset-default` (it is disabled by default). You no longer need to override it to preserve your SVG's `viewBox`. If you do need to explicitly enable `removeViewBox`, add it as a top-level plugin:
+>
+> ```typescript
+> plugins: ['preset-default', 'removeViewBox']
+> ```
 
 Disable SVGO entirely:
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.4.0",
     "mini-svg-data-uri": "^1.4.4",
-    "svgo": "^3.3.3"
+    "svgo": "^4.0.1"
   },
   "devDependencies": {
     "@cpsoinos/eslint-config-typescript": "0.2.5",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -19,7 +19,9 @@ export default defineNuxtConfig({
               },
 
               // or disable plugins
-              removeViewBox: false,
+              removeDoctype: false,
+              // Note: removeViewBox is no longer part of preset-default in SVGO v4.
+              // viewBox is preserved by default — no override needed.
             },
           },
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.4.4
         version: 1.4.4
       svgo:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^4.0.1
+        version: 4.0.1
       svgo-loader:
         specifier: ^4.0.0
         version: 4.0.0
@@ -6107,9 +6107,6 @@ packages:
   sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
-
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -6457,11 +6454,6 @@ packages:
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
     engines: {node: '>=14.0.0'}
-    hasBin: true
-
-  svgo@4.0.0:
-    resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
-    engines: {node: '>=16'}
     hasBin: true
 
   svgo@4.0.1:
@@ -13511,7 +13503,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
-      svgo: 4.0.0
+      svgo: 4.0.1
 
   postcss-svgo@7.1.2(postcss@8.5.12):
     dependencies:
@@ -13862,8 +13854,6 @@ snapshots:
       regexp-tree: 0.1.27
 
   sax@1.2.4: {}
-
-  sax@1.4.1: {}
 
   sax@1.6.0: {}
 
@@ -14280,16 +14270,6 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
-
-  svgo@4.0.0:
-    dependencies:
-      commander: 11.1.0
-      css-select: 5.1.0
-      css-tree: 3.1.0
-      css-what: 6.1.0
-      csso: 5.0.5
-      picocolors: 1.1.1
-      sax: 1.4.1
 
   svgo@4.0.1:
     dependencies:

--- a/src/module.ts
+++ b/src/module.ts
@@ -32,14 +32,7 @@ function hashCode(str: string) {
 
 export const defaultSvgoConfig: Config = {
   plugins: [
-    {
-      name: 'preset-default',
-      params: {
-        overrides: {
-          removeViewBox: false,
-        },
-      },
-    },
+    'preset-default',
     'removeDimensions',
     {
       name: 'prefixIds',

--- a/test/override.test.ts
+++ b/test/override.test.ts
@@ -34,14 +34,15 @@ describe('options override test', async () => {
     } as NuxtConfig,
   })
 
-  it('renders the svg removing the viewBox', async () => {
+  it('renders the svg with viewBox and with dimensions (custom config, no removeDimensions)', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
 
     writeFileSync('./test.log', html, { encoding: 'utf-8' })
-    // default config of module removes dimensions and adds viewbox
+    // Custom config uses preset-default only (no removeDimensions), so dimensions are preserved.
+    // In SVGO v4, removeViewBox is no longer in preset-default, so viewBox is also preserved.
     expect(html).toContain(
-      '<svg width="24" height="24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732z"></path></svg>',
+      '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M13.5 1.515a3 3 0 0 0-3 0L3 5.845a2 2 0 0 0-1 1.732V21a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6h4v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7.577a2 2 0 0 0-1-1.732z"></path></svg>',
     )
   })
 })


### PR DESCRIPTION
## Summary

Upgrades `svgo` from `^3.3.3` to `^4.0.1` and fixes the warning described in #474.

## Root Cause (issue #474)

In SVGO v3, `removeViewBox` was part of `preset-default` (enabled by default). The module's `defaultSvgoConfig` overrode it to `false` to preserve the `viewBox` attribute:

```ts
{
  name: 'preset-default',
  params: {
    overrides: {
      removeViewBox: false,  // prevented viewBox from being removed
    },
  },
}
```

In SVGO v3+, `removeViewBox` was moved out of `preset-default` entirely (now disabled by default), making the `overrides.removeViewBox` key invalid and triggering the warning:

> You are trying to configure `removeViewBox` which is not part of `preset-default`.

## Changes

### `package.json`
- Upgraded `svgo` from `^3.3.3` to `^4.0.1`

### `src/module.ts`
- Simplified `defaultSvgoConfig`: replaced the `preset-default` object with just the string `'preset-default'` since no overrides are needed
- `removeViewBox` is now disabled by default in SVGO v4, so the `viewBox` is preserved automatically — no override required

### `test/override.test.ts`
- Updated expected HTML to reflect SVGO v4 behavior: `viewBox` is preserved when using `preset-default` without explicitly adding `removeViewBox`

## SVGO v4 Breaking Changes (impact on this module)

| Change | Impact |
|--------|--------|
| `removeViewBox` removed from `preset-default` defaults | ✅ Fixed — was already the desired behavior, just needed to remove the now-invalid override |
| `removeScriptElement` renamed to `removeScripts` | No impact — module doesn't reference this plugin |
| Enforced public API boundaries | No impact — module only uses `optimize` from svgo |
| Dropped Node.js v14 support | No impact |

Closes #474