### PR TITLE
fix: let semantic-release handle npm publishing instead of manual npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm semantic-release
-
-      - name: Publish to npm
-        run: npm publish --no-git-checks

--- a/.releaserc
+++ b/.releaserc
@@ -5,12 +5,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
+    "@semantic-release/npm",
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the release workflow failure: `npm error You cannot publish over the previously published versions`.

## Root Cause

The workflow had a manual `npm publish --no-git-checks` step that ran **unconditionally** after `pnpm semantic-release`. When semantic-release determined no new release was needed (e.g. all `chore:` commits), it exited cleanly without bumping the version — but the manual publish step fired anyway, attempting to re-publish the already-published version.

## Changes

### `.github/workflows/release.yml`
- Removed the manual `Publish to npm` step

### `.releaserc`
- Removed `"npmPublish": false` override — `@semantic-release/npm` now handles publishing internally, only when it actually creates a new release

## Trusted Publishing (OIDC)

The workflow already had `id-token: write` configured. With `npmPublish` re-enabled, `@semantic-release/npm` will use npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) via GitHub Actions OIDC — no `NPM_TOKEN` secret required. Provenance attestations are generated automatically.

> **Note:** A Trusted Publisher must be configured on the [nuxt-svgo npm package settings](https://www.npmjs.com/package/nuxt-svgo) page (Publish → Trusted Publishers → Add) with:
> - **Owner:** `cpsoinos`
> - **Repository:** `nuxt-svgo`
> - **Workflow:** `release.yml`